### PR TITLE
Remove citation markers from Spanish documentation

### DIFF
--- a/docs/ANALISIS_TECNICO.md
+++ b/docs/ANALISIS_TECNICO.md
@@ -1,0 +1,49 @@
+# Análisis Técnico – Sistema de Animación Sísmica IGANIMA
+
+## 1. Resumen Ejecutivo
+IGANIMA es una tubería offline que transforma metadatos sísmicos en recursos audiovisuales. Su fortaleza radica en apoyarse en bibliotecas especializadas (ObsPy, Plotly, Manim, OpenCV) pero requiere configuraciones externas consistentes para operar. Este análisis describe la arquitectura actual, los flujos de datos, dependencias clave y riesgos técnicos.
+
+## 2. Arquitectura Actual
+### 2.1 Componentes Principales
+1. **CLI y orquestador (`run_igsismani.py`)**: Gestiona argumentos, lee configuraciones, coordina conexiones y encapsula el flujo completo desde la adquisición de datos hasta la exportación del video.
+2. **Utilidades de datos (`iganima/iganima_utils.py`)**: Proveen funciones para conectarse a servidores FDSN, obtener eventos, convertirlos en diccionarios/tablas y adjuntar metadatos (coordenadas, distancias).
+3. **Funciones de visualización (`iganima/iganima_functions.py`)**: Manipulan directorios de frames, generan geometrías (puntos, círculos, ondas) y renderizan figuras Plotly guardadas como PNG.
+4. **Escena de barras (`iganima/infobars_scene.py`)**: Define una escena Manim reusable que genera frames con texto y barras animadas sobre datos del evento.
+5. **Configuraciones**: Archivos INI y JSON que describen servidores, rutas y parámetros visuales.
+
+### 2.2 Patrón de Integración
+El orquestador actúa como secuenciador: valida la configuración, delega al módulo de utilidades para conectar y enriquecer datos, llama a las funciones de animación para producir frames y usa PIL/OpenCV para la composición final. No existe un sistema de colas; todo se ejecuta secuencialmente en memoria única.
+
+### 2.3 Flujo de Datos
+1. **Entrada**: Argumentos CLI → lectura INI/JSON → valores expanden variables de entorno.
+2. **Catálogo sísmico**: Cliente FDSN obtiene el evento → `event2dict` lo transforma → se calcula fecha/hora local.
+3. **Enriquecimiento externo**: Servicio HTTP adicional devuelve ciudad/provincia/distancia; en caso de fallo se registran valores nulos.
+4. **Frames**: `create_initial_point_frame` y `save_frame` generan PNG con Mapbox; `InfoBarsScene` produce PNG con datos textualizados.
+5. **Salida**: PIL combina mapas + barras; OpenCV compila el video MP4 que se nombra con el `event_id`.
+
+## 3. Dependencias y Servicios
+- **ObsPy FDSN Client**: descarga eventos/inventarios; requiere conectividad HTTP y certificados adecuados.
+- **Requests**: consulta de localidad más cercana; depende de un endpoint personalizado (`nearest_url`).
+- **Plotly + Mapbox**: renderizan mapas de fondo; necesitan token activo (`mapbox_access_token`).
+- **Manim + Cairo/Pango**: renderizado de barras informativas; exige stack gráfico instalado según instrucciones de Manim.
+- **PIL/OpenCV**: composición final y codificación MP4 con codec `avc1`.
+
+## 4. Calidad del Código y Observaciones
+- **Manejo de errores**: Uso sistemático de bloques `try/except` con registros detallados; sin embargo, el script termina con `sys.exit(0)` incluso ante fallas tardías, lo cual dificulta distinguir ejecuciones fallidas en pipelines automatizados.
+- **Acoplamiento**: El módulo principal importa todo (`from iganima.iganima_functions import *`), lo que oculta dependencias explícitas y dificulta pruebas unitarias.
+- **Configuración**: `load_config_from_file` expande variables de entorno recursivamente, lo cual es robusto, pero el archivo INI no es validado contra un esquema, permitiendo errores silenciosos en claves faltantes.
+- **Recursos externos**: La función `save_frame` embebe un logo remoto (GitHub raw). Una caída de red bloquearía la generación del frame, por lo que conviene incorporar el recurso localmente.
+- **Dependencia faltante**: Se importa `get_circle_color` sin implementación dentro del repositorio, lo que provocará `ImportError` si el paquete no se instala como dependencia adicional.
+
+## 5. Riesgos Técnicos
+1. **Disponibilidad de servicios externos**: FDSN y `nearest_url` son puntos únicos de fallo; no existe reintento ni caché local.
+2. **Rendimiento**: El renderizado secuencial de frames puede tardar minutos en eventos de alta resolución; no hay paralelización ni control de progreso.
+3. **Gestión de secretos**: Tokens Mapbox y credenciales FDSN se leen desde archivos sin cifrado; deben protegerse mediante permisos del sistema operativo.
+4. **Compatibilidad gráfica**: Manim depende de Cairo/Pango; servidores sin entorno gráfico pueden requerir dependencias adicionales (fonts, libs).
+
+## 6. Oportunidades de Mejora
+- Añadir validaciones formales de esquema para los archivos INI/JSON y mensajes de error más orientados al usuario.
+- Incluir una implementación local de `get_circle_color` o eliminar la dependencia si no se usa.
+- Parametrizar la ruta del logo para evitar dependencias en recursos remotos e incrementar la resiliencia offline.
+- Exponer una interfaz programática (funciones) para permitir pruebas unitarias sin ejecutar todo el pipeline CLI.
+- Registrar métricas (tiempo por frame, duración de descargas) para monitorear rendimiento y detectar cuellos de botella.

--- a/docs/DISENO_TECNICO.md
+++ b/docs/DISENO_TECNICO.md
@@ -1,0 +1,74 @@
+# Diseño Técnico del Sistema – IGANIMA
+
+## 1. Objetivo
+Este documento describe la arquitectura lógica y las decisiones de diseño que permiten a IGANIMA generar animaciones sísmicas. Se detallan componentes, contratos de datos y flujos para facilitar mantenimiento y futuras extensiones.
+
+## 2. Arquitectura Lógica
+### 2.1 Capas
+1. **Capa de Configuración y Entrada**: Procesa argumentos CLI y archivos INI/JSON. Proporciona valores normalizados (rutas, tokens, servidores) al orquestador.
+2. **Capa de Datos Sísmicos**: Se conecta al servidor FDSN, recupera el catálogo del evento y construye estructuras enriquecidas (`event_dict`, DataFrames). Incluye utilidades para adjuntar coordenadas y distancias.
+3. **Capa de Visualización**: Produce frames de mapa con Plotly/Mapbox y frames de texto con Manim; encapsula la lógica de geometrías y animaciones.
+4. **Capa de Composición/Salida**: Usa PIL/OpenCV para combinar imágenes y escribir el video final en disco.
+
+### 2.2 Diagrama de Flujo (descrito)
+1. Usuario ejecuta `python run_igsismani.py --iganima_config <cfg> --event_id <id>`.
+2. Se leen archivos INI/JSON; se construye el cliente FDSN.
+3. Se descarga el evento, se genera `event_dict` y se solicita información de proximidad.
+4. Se limpian carpetas de frames y se renderizan mapas (`map_###.png`).
+5. Se invoca `InfoBarsScene` para renderizar barras (`info_###.png`).
+6. Se combinan los pares de imágenes y se genera `EVENTO.mp4`.
+
+## 3. Componentes y Responsabilidades
+### 3.1 `run_igsismani.py`
+- **Entradas**: CLI (`argparse`), archivo INI, archivo JSON, inventario XML, servicios HTTP.
+- **Salidas**: Directorios de frames (`frames_map`, `frames_info`, `frames_combined`), video MP4 nombrado con el `event_id`.
+- **Responsabilidades**: Validar configuración, coordinar módulos, registrar errores, definir dimensiones globales (pixel/frame width/height) para Manim.
+
+### 3.2 `iganima/iganima_utils.py`
+- **Funciones clave**: `connect_fdsn`, `get_event_by_id`, `event2dict`, `attach_coordinates_from_inventory`, `create_stations_dict`.
+- **Contratos**: Devuelven objetos ObsPy enriquecidos o estructuras de Python puras listas/diccionarios; lanzan excepciones ante fallas en servicios FDSN.
+- **Decisiones de diseño**: Uso de `AttribDict` para almacenar coordenadas, conversión de fechas a hora local mediante `pytz` y normalización de estados (`status`).
+
+### 3.3 `iganima/iganima_functions.py`
+- **Funciones clave**: `clean_frames_directory`, `create_initial_point_frame`, `save_frame`, `compile_animation` (opcional).
+- **Decisiones**: Se usa Plotly Scattermapbox con `style="outdoors"`, se superpone un círculo rojo generado trigonométricamente y un logo remoto; las imágenes se guardan mediante `fig.write_image`. El zoom se interpola linealmente entre 4.5 y 9.5 para simular acercamiento.
+
+### 3.4 `iganima/infobars_scene.py`
+- **Estructura**: Clase `InfoBarsScene` que hereda de `Scene`, crea barras (`RoundedRectangle`) y textos (`Text`) en colores alternados, y captura los frames manualmente usando PIL para guardarlos como PNG.
+- **Parámetros**: `event_info` (dict), `output_dir`, `n_frames`. Los tamaños de fuente y textos se formatean en español para uso institucional.
+
+### 3.5 Composición de Frames
+- `frames_map` y `frames_info` se combinan verticalmente con `PIL.Image.new` y `paste`. Luego `cv2.VideoWriter` usa codec `avc1` y FPS configurados para producir el MP4.
+
+## 4. Modelos de Datos
+### 4.1 `event_dict`
+| Clave | Descripción | Fuente |
+| --- | --- | --- |
+| `event_id` | Identificador corto derivado de `resource_id`. | ObsPy `event.resource_id`. |
+| `latitude`, `longitude`, `depth` | Coordenadas epicentrales (km). | `preferred_origin`. |
+| `magnitude` | Magnitud redondeada (dos decimales). | `preferred_magnitude`. |
+| `status` | Traducción (Preliminar/Revisado). | `status()` utilitaria. |
+| `time_local`, `local_date`, `local_time` | Fecha/hora en `America/Guayaquil`. | `get_local_datetime`. |
+| `distance`, `city`, `province` | Enriquecimiento de `nearest_url` o `--` por defecto. | Servicio HTTP adicional. |
+
+### 4.2 Configuración INI
+- `[fdsn]`: `server_id`, `server_config_file`, `xml_inventory_file`, `nearest_url`, `nearest_token`.
+- `[animation]`: `mapbox_access_token`, `frames_map`, `frames_info`, `frames_number`, `fps`, `number_stations` (usado para otras variantes de animación).
+
+### 4.3 Configuración JSON
+Estructura `{"id": {"server_ip": "host", "port": 8080}}` usada para construir el cliente FDSN. Se expanden variables de entorno para rutas dinámicas.
+
+## 5. Estrategia de Ejecución
+1. **Preparación**: Crear entorno Conda, instalar dependencias y preparar archivos `logging.ini`, `iganima.cfg` y catálogo JSON.
+2. **Ejecución**: Invocar el script con argumentos requeridos. El ancho/alto de píxel para Manim se fija antes de llamar a `main`.
+3. **Resultados**: Directorios `frames_map`, `frames_info`, `frames_combined` y video final en el directorio actual.
+
+## 6. Extensibilidad
+- **Nuevos canales de salida**: Se puede reutilizar `frames_combined` para generar GIFs con `compile_animation` ya implementado en `iganima_functions` si se expone desde el orquestador.
+- **Soporte multi-evento**: Encapsular `main` en una función que acepte una lista de eventos permitiría ejecuciones por lotes.
+- **Tematización**: Parametrizar colores, fuentes y logos mediante la configuración permitiría adaptar la identidad visual sin modificar código.
+
+## 7. Consideraciones Operativas
+- Mantener tokens y rutas fuera del control de versiones usando variables de entorno (`$HOME`, etc.) como ya soporta `load_config_from_file`.
+- Verificar espacio en disco antes de generar frames; cada ejecución produce al menos `3 * frames_number` archivos PNG temporales.
+- Automatizar la limpieza de `frames_combined` tras exportar el video para ahorrar almacenamiento.

--- a/docs/ESPECIFICACION_REQUERIMIENTOS.md
+++ b/docs/ESPECIFICACION_REQUERIMIENTOS.md
@@ -1,0 +1,77 @@
+# Especificación de Requerimientos del Software (SRS) – IGANIMA
+
+## 1. Introducción
+### 1.1 Propósito
+El propósito de este documento es definir con precisión qué debe hacer IGANIMA, un conjunto de utilidades que genera mapas y barras informativas animadas a partir de catálogos sísmicos oficiales. El SRS describe el comportamiento funcional, las restricciones técnicas y las interfaces externas que deben respetarse para operar el script principal `run_igsismani.py` en entornos de producción o investigación.
+
+### 1.2 Alcance
+El alcance abarca la ingesta de parámetros mediante archivos INI/JSON, la conexión a servicios FDSN para recuperar la información del evento, la generación de cuadros (frames) de mapa con Plotly, la construcción de barras informativas con Manim y la composición final en video MP4. Quedan fuera de este alcance servicios de distribución o publicación web del material renderizado.
+
+### 1.3 Definiciones, acrónimos y abreviaturas
+- **FDSN**: Servicio estandarizado para el intercambio de metadatos sísmicos (FDSN Web Services).
+- **Frame**: Imagen estática generada para un instante de la animación.
+- **Mapbox**: API de mapas base utilizada para renderizar los fondos cartográficos.
+- **Manim**: Motor de animación para componer escenas tipográficas.
+
+### 1.4 Referencias
+- Archivo `README.md` para prerrequisitos y configuración general.
+- Código fuente en `run_igsismani.py`, `iganima/iganima_functions.py`, `iganima/iganima_utils.py` e `iganima/infobars_scene.py`.
+
+### 1.5 Visión General
+El resto del documento aborda la descripción general del producto (Sección 2) y los requerimientos funcionales/no funcionales específicos (Sección 3).
+
+## 2. Descripción General
+### 2.1 Perspectiva del Producto
+IGANIMA es un ejecutable por línea de comandos que actúa como cliente de un servidor FDSN interno, produce mapas con Plotly y genera gráficos adicionales con Manim. La aplicación depende de archivos de configuración externos para instanciar clientes, rutas de recursos y parámetros visuales.
+
+### 2.2 Funciones del Producto
+- Validar parámetros entregados por CLI y cargar configuraciones INI/JSON.
+- Limpiar directorios de trabajo y preparar carpetas para frames.
+- Conectarse al servicio FDSN y recuperar datos del evento y estaciones.
+- Construir anotaciones y atributos derivados (distancia a ciudades, hora local).
+- Renderizar mapas secuenciales con Mapbox y anotaciones del evento.
+- Renderizar barras informativas con Manim y exportarlas como PNG.
+- Fusionar frames, generar video MP4 y dejar evidencia en disco.
+
+### 2.3 Clases de Usuarios
+- **Analistas sísmicos**: Ejecutan el script para generar productos oficiales.
+- **Desarrolladores/DevOps**: Mantienen la integración con servicios FDSN y Mapbox.
+- **Comunicadores científicos**: Consumen los videos para difusión pública.
+
+### 2.4 Entorno Operativo
+- Python 3.13+ con dependencias: `pandas`, `numpy`, `plotly`, `moviepy`, `obspy`, `manim`, `opencv-python` y `Pillow` instalados en una máquina con acceso a internet para Mapbox/FDSN.
+- Sistema de archivos con permisos de lectura/escritura para los directorios de frames definidos en la configuración.
+
+### 2.5 Restricciones de Diseño
+- Requiere un token Mapbox válido; de lo contrario, la descarga de teselas falla.
+- Necesita catálogos XML y endpoints FDSN accesibles por HTTP.
+- La biblioteca `get_circle_color` no está presente en el repositorio, por lo que los colores concéntricos dependen de una implementación externa.
+
+### 2.6 Suposiciones y Dependencias
+- Se asume conectividad estable hacia los servicios de proximidad (`nearest_url`) para enriquecer la descripción del evento.
+- Se presume que los inventarios XML tienen los metadatos necesarios para anexar coordenadas a las trazas.
+
+## 3. Requerimientos Específicos
+### 3.1 Requerimientos Funcionales
+1. **Entrada por CLI**: El usuario debe proporcionar `--iganima_config` y `--event_id` al ejecutar el script; ambos son obligatorios y su ausencia termina en error.
+2. **Lectura de configuración**: El sistema debe aceptar archivos INI con secciones `[fdsn]` y `[animation]`, y JSON con la tabla de servidores, expandiendo variables de entorno antes de su uso.
+3. **Conexión a FDSN**: El sistema debe abrir un cliente HTTP hacia el host/puerto proporcionados y propagar errores de red en los logs.
+4. **Recuperación de eventos**: Para cada `event_id`, debe solicitarse el catálogo correspondiente y convertirlo en un diccionario enriquecido (magnitud, ubicación, hora local).
+5. **Enriquecimiento geográfico**: Se debe consultar el servicio `nearest_url` con latitud y longitud para obtener la ciudad/provincia más cercana; en caso de error se llenan campos con `--`.
+6. **Gestión de directorios**: Los directorios `frames_map` y `frames_info` se limpian antes de crear nuevos archivos para evitar residuos de ejecuciones previas.
+7. **Generación de frames de mapa**: Para cada iteración `t` hasta `frames_number`, se debe producir un archivo PNG que contenga el punto del epicentro, un círculo rojo semitransparente y el logo institucional sobre un mapa Mapbox.
+8. **Generación de barras informativas**: Se debe renderizar una secuencia de `n_frames` PNG que contenga magnitud, profundidad, distancia, ciudad, fecha y hora usando el objeto `InfoBarsScene`.
+9. **Composición final**: El sistema debe combinar verticalmente cada par de frames y generar un video MP4 usando OpenCV con el FPS definido en la configuración.
+10. **Registro de errores**: Cada bloque crítico debe capturar excepciones, registrarlas y relanzarlas para facilitar diagnósticos en lotes automatizados.
+
+### 3.2 Requerimientos de Datos
+- **Archivos de configuración**: INI (parámetros generales) y JSON (catálogo de servidores). Deben permitir variables de entorno para rutas sensibles.
+- **Inventarios XML**: Definen los metadatos de estaciones y se usan para adjuntar coordenadas cuando los servicios FDSN no proporcionan información completa.
+- **Frames**: Imágenes PNG nombradas secuencialmente (`map_###.png`, `info_###.png`) almacenadas en carpetas configurables.
+
+### 3.3 Requerimientos No Funcionales
+- **Disponibilidad**: El sistema debe tolerar fallos transitorios en servicios externos registrando errores y continuando cuando sea seguro (por ejemplo, rellenando `--`).
+- **Rendimiento**: La generación de frames debe completarse dentro de una sola ejecución secuencial; no hay paralelización implementada, por lo que el número de frames debe mantenerse moderado (20 por defecto).
+- **Usabilidad**: La interacción es por CLI; la documentación debe describir los argumentos obligatorios y ejemplos de uso.
+- **Portabilidad**: Compatible con cualquier sistema operativo que soporte Python 3.13 y las dependencias mencionadas.
+- **Seguridad**: Los tokens y rutas sensibles se pasan mediante archivos de configuración que pueden residir fuera del repositorio y usar variables de entorno para ocultar credenciales.


### PR DESCRIPTION
## Summary
- remove the inline citation markers from the Spanish SRS, analysis, and design documents to honor the requested format

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915def73ec88327a756fa7555977548)